### PR TITLE
共有を閉じただけで X が開いてしまうのを直す

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -788,21 +788,22 @@ el.btnHome.addEventListener('click', goHome);
 
 /** 結果を外へ。端末が持っていれば共有画面、無ければ X の投稿画面を開く。
     どちらも最後に人が押さないと出ていかない */
-el.btnShare.addEventListener('click', async () => {
+el.btnShare.addEventListener('click', () => {
   if (!lastResult) return;
   const url = `${location.origin}${location.pathname}#/play/${lastResult.id}`;
   const text =
     `Typing Engineer で「${lastResult.title}」を ` +
     `${lastResult.seconds.toFixed(1)}秒・正確さ ${lastResult.accuracy}% でクリアしました。`;
 
-  if (navigator.share) {
-    try {
-      await navigator.share({ title: SITE, text, url });
-      return;
-    } catch {
-      /* 閉じられただけ。下に落ちる */
-    }
+  // どちらに行くかはここで決め切る。await を挟んでから window.open を呼ぶと
+  // 「利用者の操作ではない」と見なされて塞がれる。
+  const payload = { title: SITE, text, url };
+  if (typeof navigator.share === 'function' && (navigator.canShare?.(payload) ?? true)) {
+    // 閉じられた（AbortError）ときは何もしない。X を勝手に開かない
+    navigator.share(payload).catch(() => {});
+    return;
   }
+
   window.open(
     `https://x.com/intent/post?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}`,
     '_blank',


### PR DESCRIPTION
公開先で検証して見つけた不具合です。二つ間違えていました。

## 1. 共有画面を閉じただけで X が開く

`navigator.share` の失敗をすべて同じに扱っていました。利用者が共有画面を自分で閉じると `AbortError` で戻りますが、**それも失敗と見なして X の投稿画面を開いていました。** 閉じたのに別の窓が開くのは筋が通りません。

## 2. `await` のあとで `window.open` を呼んでいた

ブラウザは「利用者の操作から続いていない」と見なして塞ぎます。**手元では通り、公開先では通りませんでした。**

## 直し方

どちらへ行くかを `await` を挟まずその場で決め切る形にしました。`canShare` があれば見て、無ければ `share` の有無だけで決めます。閉じられたときは何もしません。

## 確かめたこと

三つの経路をそれぞれ確認しました。

| 経路 | 結果 |
| --- | --- |
| 端末の共有画面へ渡す | ステージ名・タイム・正確さ・URL が渡る |
| 利用者が閉じる | **開いた窓 0**（何も起きない） |
| 共有画面を持たない | X の投稿画面が開く |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KG7FWDTHPFLyut38AfWJuN