### PR TITLE
リンクにブラウザ既定の下線が出ていたのを消す

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -77,6 +77,25 @@ body::before {
   z-index: 1;
 }
 
+/* 既定の下線と青は使わない。
+   見出しやカードまで <a> で囲っているので、そのままだと全部に線が出る */
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+/* 単独で置いてある文字のリンクだけ、狙って線を引く */
+.credit a {
+  text-decoration: underline;
+  text-decoration-color: rgba(53, 224, 46, 0.32);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}
+
+.credit a:hover {
+  text-decoration-color: currentColor;
+}
+
 :focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;


### PR DESCRIPTION
> 謎のださいテキストデコレーションない？

ありました。**`app.css` に `text-decoration` の指定が一つも無く、`a` への基本指定もありませんでした。** リンク全部にブラウザ既定の下線が出ていました。

- ヘッダーの `</> Typing Engineer`
- `ステージ` / `マイページ`
- `SCORE` の枠
- 一覧の下の記録カード（`<a>` で囲っているので**中身が全部**）
- フッターの `GitHub` / `Sponsor`

## 直し方

```css
a {
  color: inherit;
  text-decoration: none;
}
```

見出しやカードまで `<a>` で囲っているので、既定のままだと線だらけになります。

**ただしフッターの二つだけは狙って線を残しました。** 単独で置いた文字リンクなので、色だけだと押せると分かりません。緑の細い線を下に 3px 逃がしてあります。既定の青と太さは使いません。

## 確かめたこと

描画して全リンクの `text-decoration-line` を実測。`underline` が残るのはフッターの二つだけです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KG7FWDTHPFLyut38AfWJuN