### PR TITLE
検査を PR ごとに走らせる

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,21 @@
+# npm run check を PR ごとに走らせる。
+# 手元でしか回らない検査は、いずれ回されなくなる。
+name: check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      # 依存パッケージは無いので install は要らない
+      - run: npm run check

--- a/tools/check.mjs
+++ b/tools/check.mjs
@@ -82,12 +82,21 @@ function findChrome() {
       cands.push(join(cache, d, 'chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing'));
     }
   }
-  cands.push('/usr/bin/google-chrome', '/usr/bin/chromium');
+  cands.push(
+    '/usr/bin/google-chrome',
+    '/usr/bin/google-chrome-stable',
+    '/usr/bin/chromium',
+    '/usr/bin/chromium-browser',
+    '/snap/bin/chromium'
+  );
   return cands.filter(Boolean).find((p) => existsSync(p));
 }
 
 const chromeBin = findChrome();
-if (!chromeBin) {
+if (!chromeBin && process.env.CI) {
+  // CI で黙って飛ばすと、緑なのに何も見ていない状態になる。それが一番まずい
+  ng('描画', 'Chrome が見つからない（CI では飛ばさず落とす）');
+} else if (!chromeBin) {
   console.log('Chrome が見つからないので描画の検査は飛ばす（CHROME= で場所を渡せる）');
 } else {
   const PORT = 8791;
@@ -105,6 +114,8 @@ if (!chromeBin) {
       '--no-first-run',
       '--no-default-browser-check',
       '--disable-gpu',
+      // CI の入れ物では砂場が作れないことがある
+      ...(process.env.CI ? ['--no-sandbox', '--disable-dev-shm-usage'] : []),
       'about:blank',
     ],
     { stdio: ['ignore', 'ignore', 'pipe'] }


### PR DESCRIPTION
手元でしか回らない検査は、いずれ回されなくなります。`push` と `pull_request` で `npm run check` を走らせます。

依存パッケージが無いので `install` は要りません。

## Chrome が見つからないときの扱いを直しました

これまでは**黙って描画の検査を飛ばして**いました。手元ならそれでいいのですが、**CI で飛ばすと「緑なのに何も見ていない」状態**になります。それが一番まずいので、CI では飛ばさずに落とすようにしました。

あわせて CI の入れ物向けに `--no-sandbox` を渡し、探す場所に Linux のものを足しています。

**この PR 自体が最初の実行になります。** 緑になれば、CI 上でも描画の検査が本当に走っていることの証拠です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KG7FWDTHPFLyut38AfWJuN