### PR TITLE
CSP を置いて、外に出ないことを不変条件にする

### DIFF
--- a/.assetsignore
+++ b/.assetsignore
@@ -1,0 +1,28 @@
+# Cloudflare Workers に上げないもの。.gitignore と同じ書き方。
+#
+# directory を "." にしているので、書かないと開発用のものまで配られる。
+# どれも公開リポジトリに既にあるものなので漏れる話ではないが、
+# 配信するものは実際に画面で使うものだけにしておく。
+#
+# _headers はここに書かない。あれは Worker が読んで解釈する設定で、
+# アセットとしては配信されない（除外は要らない）。
+
+# 開発と検査のためのもの
+tools/
+scripts/
+package.json
+wrangler.jsonc
+
+# 説明と手続き
+README.md
+LICENSE
+.github/
+
+# GitHub Pages 用。Workers では意味を持たない
+.nojekyll
+
+# 手元にしか無いもの
+.git/
+.gitignore
+node_modules/
+.DS_Store

--- a/.assetsignore
+++ b/.assetsignore
@@ -25,4 +25,13 @@ LICENSE
 .git/
 .gitignore
 node_modules/
+.wrangler/
 .DS_Store
+
+# node_modules を外すのは念のためではない。
+# wrangler.jsonc が無いまま `npx wrangler deploy` を走らせると、wrangler が
+# 対話セットアップを始めて自分を devDependency として入れる。すると
+# directory: "." の下に node_modules ができ、workerd の実行ファイル（122 MiB）が
+# 25 MiB の上限を超えてデプロイが落ちる。一度そうなった。
+#
+# wrangler.jsonc を置いた以上その道は通らないが、外し忘れると同じ壊れ方をする。

--- a/README.md
+++ b/README.md
@@ -230,44 +230,42 @@ CSP が食い違うと、破ったことに気づくのが公開後になる**�
 
 ## 公開先
 
-いま **GitHub Pages と Cloudflare Pages の二本を並走させて**見比べています。
+いま **GitHub Pages と Cloudflare Workers の二本を並走させて**見比べています。
 
 | | |
 | --- | --- |
 | GitHub Pages | 現行。帯域幅 100 GB/月（ソフト）。**ヘッダーを一切指定できない** |
-| Cloudflare Pages | 静的配信は無料・無制限。`_headers` で CSP を置ける |
+| Cloudflare Workers | 静的配信は無料・無制限。`_headers` で CSP を置ける |
 
-Cloudflare に移す理由は帯域幅ではありません（264 KB のサイトで 100 GB には
-届きません）。**ヘッダーを置けることです。** 上の「外部に依存しない」を
-宣言から不変条件に変えられるのは、こちらだけです。
+移す理由は帯域幅ではありません（264 KB のサイトで 100 GB には届きません）。
+**ヘッダーを置けることです。** 上の「外部に依存しない」を宣言から
+不変条件に変えられるのは、こちらだけです。
 
 `_headers` は GitHub Pages では単に無視されるので、並走中に困りません。
 ハッシュルーティング（`#/play/...`）なのでリライトの設定も要りません。
 
-### Cloudflare 側の設定
+### Pages ではなく Workers
 
-| 項目 | 値 |
-| --- | --- |
-| Framework preset | None |
-| Build command | **空欄** |
-| Build output directory | `/` |
-| 環境変数 | なし |
+Cloudflare には Pages と Workers の二つがあり、**Workers を選びました。**
+Cloudflare 自身が「新規プロジェクトは Workers で始めるべき。Pages は引き続き
+サポートするが、今後の投資・最適化・機能開発は Workers に専念する」と
+言っているためです。静的アセットの `_headers` はどちらでも同じ構文で使えます。
 
-**Build command は空です。** ビルドが無いので、Git 連携なら Cloudflare が
-リポジトリの中身をそのまま配ります。
+`wrangler.jsonc` に `main` は書いていません。振る舞いを足すつもりが無いので、
+アセットを配るだけで足ります。Worker のコードが無いぶん、動く部分が減ります。
 
-ここに `npx wrangler deploy` と書くと落ちます。三つ理由があります。
-`wrangler deploy` は Workers 用で Pages は `wrangler pages deploy` である、
-`wrangler.toml` を要求されるがこのリポジトリには無い、そして Git 連携では
-wrangler そのものが要らない。
+`assets.directory` は `.` です。`index.html` があるのがリポジトリの根で、
+**`_headers` もそこに要る**ためです。Workers は `_headers` を
+アセットディレクトリの直下でだけ読みます。
 
-**ビルドトークンも要りません。** あれは Direct Upload（CI から
-`wrangler pages deploy` を叩く形）のためのもので、Git 連携では認証が
-GitHub App 側で済んでいます。
+配りたくないものは `.assetsignore` で外します（`tools/` `scripts/` `README.md`
+など）。`_headers` は書きません。あれは Worker が読んで解釈する設定で、
+アセットとしては配信されないからです。
 
-空にしておく理由はもう一つあります。`npx` は**ビルドのたびに npm から
-パッケージを取ってきます。** 空にすれば、配信の経路にも依存パッケージが
-ゼロになります。Heroku で丸ごと止まったときの教訓と同じ話です。
+**この二つのファイルは `npm run check` が検査しています。**
+とくに `_headers` がアセットディレクトリの直下にあること。ここがずれると
+**CSP が黙って効かなくなります。** 落ちも警告も出ず、ヘッダーだけが消えます。
+しかも手元の `npm run dev` は根から読むので通ってしまいます。
 
 ## 検査（`npm run check`）
 
@@ -281,6 +279,7 @@ GitHub App 側で済んでいます。
 | ボタン | 既定の見た目が残っていないか（`cursor` と角丸） |
 | 色 | **どの配色でも文字が読めるか。** `--pending` `--fg` `--fg-mid` `--fg-dim` と字句の色の、**その配色の地**に対する対比を実測し、4.5:1 を下回ったら落とす（注釈だけは 3:1） |
 | 幅 | 横に溢れていないか |
+| 公開の設定 | **`_headers` が `assets.directory` の直下にあるか。** ずれると CSP が黙って効かなくなる（手元の `npm run dev` は根から読むので通ってしまう）。`.assetsignore` が `index.html` や `assets/` を外していないか |
 | CSP | **二方向から見る。** 壊していないか（5 言語ぶんの完成形を描いて違反ゼロ、JS 課題は canvas に色が乗ったかまで見る）と、効いているか（外へ `fetch` して **CSP が止めたことを違反の発火で確かめる**）。`fetch` の失敗だけを見ると CORS や不通と区別が付かず、CSP を消しても通ってしまう |
 
 **依存パッケージは足していません。** Chrome を起動して DevTools Protocol を直に叩いています。
@@ -314,7 +313,9 @@ assets/js/
   sound.js          打鍵音（音声ファイルは持たず合成する）
   view-compose.js   打った docker-compose.yml を構成図にする
   view-routes.js    打った routes.rb を `rails routes` の表にする
-_headers            CSP などのヘッダー（Cloudflare Pages が読む）
+_headers            CSP などのヘッダー（Cloudflare Workers が読む）
+.assetsignore       配信しないもの（tools/ scripts/ README.md など）
+wrangler.jsonc      Workers の設定。main は無く、アセットを配るだけ
 scripts/dev-server.mjs
 scripts/headers.mjs   _headers を読む。dev-server と check が共有する
 tools/check.mjs

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ HTML と CSS を一字ずつ打つタイピング練習。
 単色の燐光を選ぶと 2020 年の版の面影が出ます。黒地に `#35E02E`、上帯は緑地に黒文字
 （当時の `.navbar` そのまま）、打った字だけが燐光します。四角い端末カーソル、走査線。
 
-**配色は十一種。** 既定は「カラフル」です。
+**配色は 11 種。** 既定は「カラフル」です。
 
 | 系統 | |
 | --- | --- |
@@ -232,10 +232,10 @@ npm run check   # 下の検査。落ちたら終了コードが 1 になる
 | 題材データ | id の重複、必須の項目、分類が GROUPS にあるか、**打つ字が ASCII だけか**、打鍵数が 120〜1200 に収まるか、題が動詞ひとつで終わっていないか |
 | 訳 | 課題・作品・アチーブメントが `en` を持つか、辞書の鍵が両言語で揃っているか、画面の印が辞書にあるか、**英語で日本語が残っていないか** |
 | 描画できたか | **一覧に札が一枚も出ていなければ落とす。** これが無いと、読み込みで落ちて真っ白でも下の検査は通ってしまう |
-| README | 書いてある題材の本数が実際と合っているか |
+| README | **書いてあるとおりに手を動かして壊れないか。** 題材・配色・アチーブメントの数、構成の一覧に `assets/js` の全ファイルが載っているか、そして**「題材を足す」の例が実際に検査を通る形か**（項目の抜け、`GROUPS` に無い分類、`en` の抜け） |
 | リンク | **ブラウザ既定の下線が出ていないか**（`.credit` は狙って引いているので除く） |
 | ボタン | 既定の見た目が残っていないか（`cursor` と角丸） |
-| 色 | **五色すべてで文字が読めるか。** `--pending` `--fg` `--fg-mid` `--fg-dim` の黒地に対する対比を実測し、4.5:1 を下回ったら落とす |
+| 色 | **どの配色でも文字が読めるか。** `--pending` `--fg` `--fg-mid` `--fg-dim` と字句の色の、**その配色の地**に対する対比を実測し、4.5:1 を下回ったら落とす（注釈だけは 3:1） |
 | 幅 | 横に溢れていないか |
 
 **依存パッケージは足していません。** Chrome を起動して DevTools Protocol を直に叩いています。
@@ -255,35 +255,55 @@ ES モジュールを使っているので `file://` で直接開いても動か
 index.html
 assets/css/app.css
 assets/js/
-  app.js         画面の組み立てと打鍵の受け取り
-  engine.js      打鍵の判定と集計（DOM も音も知らない）
-  preview.js     打った所までを描く
-  highlight.js   HTML / CSS の色分け（依存なしの字句解析）
-  lessons.js     題材
-  sound.js       打鍵音（音声ファイルは持たず合成する）
-  storage.js     自己ベスト
+  app.js            画面の組み立てと打鍵の受け取り
+  engine.js         打鍵の判定と集計（DOM も音も知らない）
+  preview.js        打った所までを描く
+  highlight.js      HTML / CSS の色分け（依存なしの字句解析）
+  lessons.js        題材と作品
+  i18n.js           日本語と英語の文言
+  tone.js           配色（11 種。単色の燐光とエディタ配色の二系統）
+  matrix.js         緑のときだけ一覧の背後に降る字
+  mypage.js         マイページの組み立て
+  trophies.js       スコア・ランク・アチーブメント
+  storage.js        自己ベストと記録（localStorage）
+  sound.js          打鍵音（音声ファイルは持たず合成する）
+  view-compose.js   打った docker-compose.yml を構成図にする
+  view-routes.js    打った routes.rb を `rails routes` の表にする
 scripts/dev-server.mjs
+tools/check.mjs
 ```
+
+`view-compose.js` と `view-routes.js` があるのは、Docker も Rails も
+ブラウザでは動かせないからです。動かせない代わりに、**打った内容を読んで
+図と表にします。** `resources :posts` と打った瞬間に七行が現れます。
 
 ### 題材を足す
 
 `assets/js/lessons.js` に一つ足すだけです。**`code` は必ず ASCII だけで書きます。**
 日本語が混ざると IME が要り、打鍵を受け取れなくなります。
 
+**`en` も要ります。** 無いと英語に切り替えたときそこだけ日本語で残るので、
+`npm run check` が落とします。
+
 ```js
 {
   id: 'css-gradient',
-  group: '王道パターン',   // '基礎' か '王道パターン'
-  lang: 'css',        // 'html' か 'css'
+  group: 'patterns',  // 'visual' 'patterns' 'apps' 'games' 'config' 'basics'
+  lang: 'css',        // 'html' 'css' 'js' 'yaml' 'ruby'
   file: 'hero.css',
   level: 3,           // 1〜4
   title: '背景をぼかす',
   subtitle: 'グラデーション',
   note: '一覧のカードに出る一行。',
-  scaffold: '<div class="hero">Hello</div>',  // lang: 'css' のときだけ
+  en: { title: 'Blur the background', subtitle: 'Gradients', note: 'One line on the card.' },
+  scaffold: '<div class="hero">Hello</div>',  // lang が 'css' 'js' のときは要る
   code: '.hero {\n  background: linear-gradient(...);\n}\n',
 }
 ```
+
+**この例そのものを `npm run check` が検査しています。** 項目が足りない、
+分類が `GROUPS` に無い、といったズレは落ちます。README を写して手が止まる、
+ということが起きないようにするためです。
 
 ## 外部に依存しない
 

--- a/README.md
+++ b/README.md
@@ -225,6 +225,50 @@ npm run dev     # http://localhost:8000/
 npm run check   # 下の検査。落ちたら終了コードが 1 になる
 ```
 
+`npm run dev` は `_headers` を読んで同じヘッダーを付けます。**手元と公開先で
+CSP が食い違うと、破ったことに気づくのが公開後になる**ためです。
+
+## 公開先
+
+いま **GitHub Pages と Cloudflare Pages の二本を並走させて**見比べています。
+
+| | |
+| --- | --- |
+| GitHub Pages | 現行。帯域幅 100 GB/月（ソフト）。**ヘッダーを一切指定できない** |
+| Cloudflare Pages | 静的配信は無料・無制限。`_headers` で CSP を置ける |
+
+Cloudflare に移す理由は帯域幅ではありません（264 KB のサイトで 100 GB には
+届きません）。**ヘッダーを置けることです。** 上の「外部に依存しない」を
+宣言から不変条件に変えられるのは、こちらだけです。
+
+`_headers` は GitHub Pages では単に無視されるので、並走中に困りません。
+ハッシュルーティング（`#/play/...`）なのでリライトの設定も要りません。
+
+### Cloudflare 側の設定
+
+| 項目 | 値 |
+| --- | --- |
+| Framework preset | None |
+| Build command | **空欄** |
+| Build output directory | `/` |
+| 環境変数 | なし |
+
+**Build command は空です。** ビルドが無いので、Git 連携なら Cloudflare が
+リポジトリの中身をそのまま配ります。
+
+ここに `npx wrangler deploy` と書くと落ちます。三つ理由があります。
+`wrangler deploy` は Workers 用で Pages は `wrangler pages deploy` である、
+`wrangler.toml` を要求されるがこのリポジトリには無い、そして Git 連携では
+wrangler そのものが要らない。
+
+**ビルドトークンも要りません。** あれは Direct Upload（CI から
+`wrangler pages deploy` を叩く形）のためのもので、Git 連携では認証が
+GitHub App 側で済んでいます。
+
+空にしておく理由はもう一つあります。`npx` は**ビルドのたびに npm から
+パッケージを取ってきます。** 空にすれば、配信の経路にも依存パッケージが
+ゼロになります。Heroku で丸ごと止まったときの教訓と同じ話です。
+
 ## 検査（`npm run check`）
 
 | 見ているもの | |
@@ -237,6 +281,7 @@ npm run check   # 下の検査。落ちたら終了コードが 1 になる
 | ボタン | 既定の見た目が残っていないか（`cursor` と角丸） |
 | 色 | **どの配色でも文字が読めるか。** `--pending` `--fg` `--fg-mid` `--fg-dim` と字句の色の、**その配色の地**に対する対比を実測し、4.5:1 を下回ったら落とす（注釈だけは 3:1） |
 | 幅 | 横に溢れていないか |
+| CSP | **二方向から見る。** 壊していないか（5 言語ぶんの完成形を描いて違反ゼロ、JS 課題は canvas に色が乗ったかまで見る）と、効いているか（外へ `fetch` して **CSP が止めたことを違反の発火で確かめる**）。`fetch` の失敗だけを見ると CORS や不通と区別が付かず、CSP を消しても通ってしまう |
 
 **依存パッケージは足していません。** Chrome を起動して DevTools Protocol を直に叩いています。
 
@@ -269,7 +314,9 @@ assets/js/
   sound.js          打鍵音（音声ファイルは持たず合成する）
   view-compose.js   打った docker-compose.yml を構成図にする
   view-routes.js    打った routes.rb を `rails routes` の表にする
+_headers            CSP などのヘッダー（Cloudflare Pages が読む）
 scripts/dev-server.mjs
+scripts/headers.mjs   _headers を読む。dev-server と check が共有する
 tools/check.mjs
 ```
 
@@ -312,6 +359,16 @@ tools/check.mjs
 2020 年の版は Heroku・Font Awesome・期限付きの署名付き S3 URL に寄りかかっていて、
 Heroku の無料プランが終わった時点で丸ごと動かなくなりました。同じ壊れ方をしないよう、
 外に置いたものは持ち込んでいません。
+
+**これは長いあいだ宣言でした。いまは `_headers` の CSP が強制します。**
+`connect-src 'none'` を置いてあるので、うっかり CDN の URL を書いた時点で
+ブラウザが止めます。効いていることは `npm run check` が実測しています
+（外へ `fetch` して、CSP が止めたことを違反の発火で確かめる）。
+
+`script-src` と `style-src` の `'unsafe-inline'` は外せません。打った字を
+`srcdoc` に流して走らせるのがこの入れ物の主題で、中身は一打ごとに変わるので
+ハッシュも nonce も置けません。**ここで守れるのは「インラインを止めること」ではなく
+「外に出る通信をゼロに保つこと」です。** `connect-src` が本体で、あとは付随です。
 
 ## 2020 年の版から変わったところ
 

--- a/_headers
+++ b/_headers
@@ -1,0 +1,22 @@
+# Cloudflare Pages が読むヘッダー定義。GitHub Pages は読まないので、
+# 並走しているあいだ、効くのは Cloudflare 側だけ。
+#
+# 置いた理由。README は「ネットワークへ出ていく通信はゼロ」と書いてきたが、
+# それは宣言にとどまっていた。connect-src 'none' を置くと、うっかり CDN の
+# URL を書いた時点でブラウザが止める。宣言が不変条件になる。
+# GitHub Pages ではヘッダーを一切指定できないので、これは移行しないと手に入らない。
+#
+# script-src と style-src の 'unsafe-inline' は外せない。打った字を srcdoc に
+# 流して走らせるのがこの入れ物の主題で、中身は一打ごとに変わるからハッシュも
+# nonce も置けない。srcdoc は親の CSP を継ぐので、緩めるしかない。
+# つまりここで守れるのは「インラインを止めること」ではなく
+# 「外に出る通信をゼロに保つこと」。connect-src が本体で、あとは付随。
+#
+# 手元でも同じヘッダーが付く（scripts/dev-server.mjs がこのファイルを読む）。
+# 破れていないことは npm run check が実測する。
+
+/*
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'none'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'
+  Referrer-Policy: no-referrer
+  X-Content-Type-Options: nosniff
+  Permissions-Policy: geolocation=(), camera=(), microphone=(), usb=(), payment=()

--- a/scripts/dev-server.mjs
+++ b/scripts/dev-server.mjs
@@ -6,9 +6,14 @@
 import { createServer } from 'node:http';
 import { readFile, stat } from 'node:fs/promises';
 import { extname, join, normalize, resolve } from 'node:path';
+import { readHeaders } from './headers.mjs';
 
 const ROOT = resolve(import.meta.dirname, '..');
 const PORT = Number(process.env.PORT) || 8000;
+
+// Cloudflare Pages に置く _headers を、手元でも同じように付ける。
+// ここで付けないと CSP は本番でしか効かず、破ったことに気づくのが公開後になる。
+const HEADERS = readHeaders(ROOT);
 
 const TYPES = {
   '.html': 'text/html; charset=utf-8',
@@ -41,6 +46,7 @@ const server = createServer(async (req, res) => {
     res.writeHead(200, {
       'Content-Type': TYPES[extname(file)] || 'application/octet-stream',
       'Cache-Control': 'no-store',
+      ...HEADERS,
     });
     res.end(body);
   } catch {

--- a/scripts/headers.mjs
+++ b/scripts/headers.mjs
@@ -1,0 +1,33 @@
+// _headers（Cloudflare Pages の形式）を読む。
+//
+// dev-server と check の両方から使う。dev-server を直に import すると
+// サーバーが立ってしまうので、読むところだけ切り出してある。
+//
+// 読むのは `/*` の段だけ。パスごとの出し分けはしていないので、それで足りる。
+
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const DEFAULT_ROOT = resolve(import.meta.dirname, '..');
+
+export function readHeaders(root = DEFAULT_ROOT) {
+  const out = {};
+  let src;
+  try {
+    src = readFileSync(join(root, '_headers'), 'utf8');
+  } catch {
+    return out; // 無ければ何も付けない
+  }
+  let inAll = false;
+  for (const line of src.split('\n')) {
+    if (!line.trim() || line.trim().startsWith('#')) continue;
+    if (!/^\s/.test(line)) {
+      inAll = line.trim() === '/*'; // 段の見出し
+      continue;
+    }
+    if (!inAll) continue;
+    const i = line.indexOf(':');
+    if (i > 0) out[line.slice(0, i).trim()] = line.slice(i + 1).trim();
+  }
+  return out;
+}

--- a/tools/check.mjs
+++ b/tools/check.mjs
@@ -192,6 +192,47 @@ else {
   if (/connect-src[^;]*(https?:|\*)/.test(CSP)) ng('CSP', 'connect-src が外を向いている');
 }
 
+// ---------------------------------------------------------------- 公開先の設定
+//
+// Workers は _headers を「アセットディレクトリの直下」でだけ読む。置き場所が
+// ずれると CSP は黙って効かなくなる。落ちも警告も出ず、ヘッダーだけが消える。
+// 手元では dev-server が ROOT から読むので、そちらは通ってしまう。
+//
+// .assetsignore で index.html や assets/ を外してしまうのも同じ質の事故で、
+// 配信されないものは検査もできない。
+
+const wranglerSrc = readFileSync(join(ROOT, 'wrangler.jsonc'), 'utf8');
+// jsonc のコメントを落としてから読む
+const wrangler = JSON.parse(wranglerSrc.replace(/^\s*\/\/.*$/gm, ''));
+
+const assetsDir = wrangler.assets?.directory;
+if (!assetsDir) ng('公開', 'wrangler.jsonc に assets.directory が無い');
+else {
+  // _headers がアセットディレクトリの直下にあること。ここが本題
+  const headersAt = resolve(ROOT, assetsDir, '_headers');
+  if (headersAt !== resolve(ROOT, '_headers')) {
+    ng('公開', `_headers が assets.directory ("${assetsDir}") の直下に無い。Workers は読まない`);
+  }
+  if (!existsSync(headersAt)) ng('公開', `${assetsDir} に _headers が無い`);
+}
+
+// name が無いとデプロイ先が定まらない
+if (!wrangler.name) ng('公開', 'wrangler.jsonc に name が無い');
+if (!wrangler.compatibility_date) ng('公開', 'wrangler.jsonc に compatibility_date が無い');
+
+// 画面に要るものを .assetsignore で外していないか。
+// 書いている範囲の書き方しか見ない（gitignore の全部は解釈しない）
+const ignoreSrc = existsSync(join(ROOT, '.assetsignore'))
+  ? readFileSync(join(ROOT, '.assetsignore'), 'utf8')
+  : '';
+const patterns = ignoreSrc.split('\n').map((l) => l.trim()).filter((l) => l && !l.startsWith('#'));
+for (const must of ['index.html', 'assets/css/app.css', 'assets/js/app.js']) {
+  for (const p of patterns) {
+    const hit = p.endsWith('/') ? must.startsWith(p) : must === p || must.startsWith(`${p}/`);
+    if (hit) ng('公開', `.assetsignore の "${p}" が ${must} を外している`);
+  }
+}
+
 console.log(`題材 ${LESSONS.length} 本・分類 ${GROUPS.length} 個を検査`);
 
 // ---------------------------------------------------------------- 2. 描画

--- a/tools/check.mjs
+++ b/tools/check.mjs
@@ -35,11 +35,16 @@ const { TROPHIES } = await import(join(ROOT, 'assets/js/trophies.js'));
 const { DICT } = await import(join(ROOT, 'assets/js/i18n.js'));
 
 const LANGS = new Set(['html', 'css', 'js', 'yaml', 'ruby']);
+
+// 題材に要る項目。README の「題材を足す」の例も同じ一覧で検査するので、
+// ここを増やせば例に書き足すまで検査が落ちる
+const REQUIRED_KEYS = ['id', 'group', 'lang', 'file', 'level', 'title', 'subtitle', 'note', 'code'];
+
 const seen = new Set();
 
 for (const l of LESSONS) {
   const at = `題材 ${l.id || '(id なし)'}`;
-  for (const key of ['id', 'group', 'lang', 'file', 'level', 'title', 'subtitle', 'note', 'code']) {
+  for (const key of REQUIRED_KEYS) {
     if (!l[key]) ng(at, `${key} が無い`);
   }
   if (seen.has(l.id)) ng(at, 'id が重複している');
@@ -105,12 +110,64 @@ for (const m of html.matchAll(/data-i18n-attr="[^:]+:([^"]+)"/g)) {
   if (!ja.has(m[1])) ng('訳', `画面の印 "${m[1]}" が辞書に無い`);
 }
 
-// README に書いた本数が実際と合っているか
+// ---------------------------------------------------------------- README と実装のズレ
+//
+// README は実装より先に古くなる。ただし古さの全部が害ではないので、
+// 「書いてあるとおりに手を動かすと壊れる」種類だけを見張る。
+// 文章の良し悪しは見ない。
+//
+// これを足したのは、分類を日本語から id に改めたときに README の例が
+// '王道パターン' のまま残り、README を写して題材を足すと GROUPS に
+// 無い分類になる状態を取り逃したから。
+
 const readme = readFileSync(join(ROOT, 'README.md'), 'utf8');
-const declared = readme.match(/^(\d+)\s*本[。、]/m);
-if (!declared) ng('README', '題材の本数が書かれていない');
-else if (Number(declared[1]) !== LESSONS.length) {
-  ng('README', `本数が食い違う（README ${declared[1]} 本 / 実際 ${LESSONS.length} 本）`);
+
+// (1) 数。README には一度だけ書き、実際の数と突き合わせる
+for (const [what, re, actual] of [
+  ['題材', /^(\d+)\s*本[。、]/m, LESSONS.length],
+  ['配色', /配色は\s*(\d+)\s*種/, TONES.length],
+  ['アチーブメント', /アチーブメントは\s*(\d+)\s*個/, TROPHIES.length],
+]) {
+  const m = readme.match(re);
+  if (!m) ng('README', `${what}の数が書かれていない`);
+  else if (Number(m[1]) !== actual) {
+    ng('README', `${what}の数が食い違う（README ${m[1]} / 実際 ${actual}）`);
+  }
+}
+
+// (2) 構成の一覧。assets/js に足したファイルが載っていないと、
+//     どこに何があるかを README から辿れない
+const structure = readme.match(/##\s*構成\s*\n+```\n([\s\S]*?)```/);
+if (!structure) ng('README', '構成の一覧が見つからない');
+else {
+  const listed = structure[1];
+  const real = readdirSync(join(ROOT, 'assets/js')).filter((n) => n.endsWith('.js'));
+  for (const f of real) if (!listed.includes(f)) ng('README', `構成に ${f} が無い`);
+  for (const m of listed.matchAll(/^\s+(\S+\.js)\b/gm)) {
+    if (!real.includes(m[1])) ng('README', `構成の ${m[1]} は実在しない`);
+  }
+}
+
+// (3) 「題材を足す」の例。これを写して題材を足す人がいるので、
+//     例そのものが上の検査を通る形でなければ意味がない
+const sample = readme.match(/###\s*題材を足す[\s\S]*?```js\n([\s\S]*?)```/);
+if (!sample) ng('README', '題材を足す例が見つからない');
+else {
+  const src = sample[1];
+  for (const k of REQUIRED_KEYS) {
+    if (!new RegExp(`^\\s*${k}:`, 'm').test(src)) ng('README', `題材を足す例に ${k} が無い`);
+  }
+  // en が無い例を写すと、訳の検査で落ちる
+  if (!/^\s*en:\s*\{/m.test(src)) ng('README', '題材を足す例に en が無い');
+
+  // 値も、注釈に並べた選択肢も、実装が受け取れる字であること
+  for (const [field, allowed] of [['group', GROUPS], ['lang', [...LANGS]]]) {
+    const line = src.split('\n').find((l) => l.trim().startsWith(`${field}:`));
+    if (!line) continue; // 上で報告済み
+    for (const m of line.matchAll(/'([^']*)'/g)) {
+      if (!allowed.includes(m[1])) ng('README', `題材を足す例の ${field} "${m[1]}" は実装に無い`);
+    }
+  }
 }
 
 console.log(`題材 ${LESSONS.length} 本・分類 ${GROUPS.length} 個を検査`);

--- a/tools/check.mjs
+++ b/tools/check.mjs
@@ -268,6 +268,12 @@ if (!chromeBin && process.env.CI) {
       return r.result?.result?.value;
     };
 
+    // Page を開けておかないと addScriptToEvaluateOnNewDocument が効かない。
+    // これが無いあいだ window.__err はずっと undefined で、読み込みで落ちた
+    // ときの理由が「(見当たらない)」になっていた。仕込みが空振りしていても
+    // 検査は緑になるので、気づくのに時間がかかった
+    await send('Page.enable');
+
     // 読み込みで落ちたら、その中身を後で読めるように控えておく
     await send('Page.addScriptToEvaluateOnNewDocument', {
       source: 'addEventListener("error", (e) => { window.__err = String(e.message); });',

--- a/tools/check.mjs
+++ b/tools/check.mjs
@@ -33,6 +33,7 @@ const { TONES } = await import(join(ROOT, 'assets/js/tone.js'));
 const { SERIES } = await import(join(ROOT, 'assets/js/lessons.js'));
 const { TROPHIES } = await import(join(ROOT, 'assets/js/trophies.js'));
 const { DICT } = await import(join(ROOT, 'assets/js/i18n.js'));
+const { readHeaders } = await import(join(ROOT, 'scripts/headers.mjs'));
 
 const LANGS = new Set(['html', 'css', 'js', 'yaml', 'ruby']);
 
@@ -170,6 +171,27 @@ else {
   }
 }
 
+// ---------------------------------------------------------------- CSP の中身
+//
+// README は「ネットワークへ出ていく通信はゼロ」と書いてきた。_headers の
+// connect-src 'none' はそれを宣言から不変条件に変えるものなので、
+// 消えたり緩んだりしたら落とす。
+//
+// script-src と style-src の 'unsafe-inline' は外せない。打った字を srcdoc に
+// 流して走らせるのが主題で、中身は一打ごとに変わるからハッシュも nonce も
+// 置けない。だからここで守るのは「外に出ないこと」だけ、と割り切っている。
+
+const HEADERS = readHeaders(ROOT);
+const CSP = HEADERS['Content-Security-Policy'];
+if (!CSP) ng('CSP', '_headers に Content-Security-Policy が無い');
+else {
+  for (const need of ["default-src 'self'", "connect-src 'none'", "object-src 'none'", "base-uri 'none'"]) {
+    if (!CSP.includes(need)) ng('CSP', `${need} が無い`);
+  }
+  // ここが緩むと、外に出られるのに気づけない
+  if (/connect-src[^;]*(https?:|\*)/.test(CSP)) ng('CSP', 'connect-src が外を向いている');
+}
+
 console.log(`題材 ${LESSONS.length} 本・分類 ${GROUPS.length} 個を検査`);
 
 // ---------------------------------------------------------------- 2. 描画
@@ -274,9 +296,18 @@ if (!chromeBin && process.env.CI) {
     // 検査は緑になるので、気づくのに時間がかかった
     await send('Page.enable');
 
-    // 読み込みで落ちたら、その中身を後で読めるように控えておく
+    // 読み込みで落ちたら、その中身を後で読めるように控えておく。
+    // CSP 違反も同じところで拾う（srcdoc の中で出たものは親へ送る）
     await send('Page.addScriptToEvaluateOnNewDocument', {
-      source: 'addEventListener("error", (e) => { window.__err = String(e.message); });',
+      source: `
+        addEventListener("error", (e) => { window.__err = String(e.message); });
+        window.__csp = [];
+        addEventListener("securitypolicyviolation", (e) => {
+          const line = e.violatedDirective + " ← " + (e.blockedURI || "(inline)");
+          window.__csp.push(line);
+          try { if (top !== window && top.__csp) top.__csp.push("[frame] " + line); } catch {}
+        });
+      `,
     });
     await send('Page.navigate', { url: `http://127.0.0.1:${PORT}/` });
 
@@ -304,6 +335,74 @@ if (!chromeBin && process.env.CI) {
     const left = await evaluate(`(${String(japaneseLeft)})()`);
     for (const s of left) ng('訳', `英語なのに日本語が残っている: ${JSON.stringify(s)}`);
     await evaluate('document.querySelector(\'[data-lang-set="ja"]\').click()');
+
+    // ---- CSP。二方向から見る。何も壊していないかと、本当に効いているか。
+    //      効いていない CSP を置くのが一番まずい。宣言だけ増えて何も守らない
+
+    // (1) サーバーが実際に送っているか。画面から fetch しても connect-src 'none'
+    //     に阻まれて確かめられないので、Node から見る
+    const sent = (await fetch(`http://127.0.0.1:${PORT}/`)).headers.get('content-security-policy');
+    if (!sent) ng('CSP', 'サーバーがヘッダーを送っていない');
+    else if (sent !== CSP) ng('CSP', `送られたヘッダーが _headers と違う\n    送: ${sent}\n    書: ${CSP}`);
+
+    // (2) 何も壊していないか。完成形を lang ごとに一本ずつ描かせて違反を数える。
+    //     srcdoc に流したインラインスクリプトが止められると JS の課題が死ぬので、
+    //     canvas に色が乗ったかまで見て「本当に走った」ことを確かめる
+    const oneEach = [...new Set(LESSONS.map((l) => l.lang))]
+      .map((lang) => LESSONS.find((l) => l.lang === lang));
+    for (const l of oneEach) {
+      const drew = await evaluate(`(async () => {
+        const { Preview } = await import('/assets/js/preview.js');
+        const { findLesson } = await import('/assets/js/lessons.js');
+        const lesson = findLesson(${JSON.stringify(l.id)});
+        const p = new Preview(document.getElementById('preview'));
+        p.mount(lesson);
+        p.render(lesson.code);
+        await new Promise((r) => setTimeout(r, 500));
+        const d = document.getElementById('preview').contentDocument;
+        const cv = d && d.getElementById('cv');
+        if (cv) {
+          // 塗られていれば alpha が立つ。CSP で止まれば透明のまま
+          const px = cv.getContext('2d').getImageData(1, 1, 1, 1).data;
+          if (!px[3]) return 'canvas が塗られていない（インラインスクリプトが走っていない）';
+        }
+        return (d && d.body && d.body.innerHTML.length) ? '' : 'プレビューが空';
+      })()`).catch((e) => `描けなかった: ${e.message}`);
+      if (drew) ng('CSP', `${l.id}（${l.lang}）で ${drew}`);
+    }
+    // 仕込みが入っていなければ落とす。空振りは「違反ゼロ」と見分けが付かず、
+    // 何も見ていないのに緑になる。それが一番まずい
+    const seenCsp = await evaluate('window.__csp ? JSON.stringify(window.__csp) : ""');
+    if (!seenCsp) ng('CSP', '違反を拾う仕込みが入っていない（検査が空振りしている）');
+    else for (const v of new Set(JSON.parse(seenCsp))) ng('CSP', `違反が出ている: ${v}`);
+
+    // (3) 効いているか。外に出ようとしたとき CSP が実際に止めたことを、
+    //     violation が発火したかで見る。
+    //
+    //     fetch が失敗したことだけを見てはいけない。CORS でも、ネットワークが
+    //     繋がっていないときでも同じように失敗するので、CSP を丸ごと消しても
+    //     この検査は通ってしまう。止めた主体が CSP だと言えるのは violation だけ。
+    const teeth = await evaluate(`(async () => {
+      if (!window.__csp) return ['違反を拾う仕込みが入っていない'];
+      window.__csp.length = 0;
+      const out = [];
+      try { await fetch('https://example.com'); } catch {}
+      await new Promise((r) => {
+        const s = document.createElement('script');
+        s.onload = s.onerror = () => r();
+        s.src = 'https://example.com/x.js';
+        document.head.append(s);
+        setTimeout(r, 2000);
+      });
+      await new Promise((r) => setTimeout(r, 200));
+      const got = window.__csp.join(' | ');
+      if (!/connect-src/.test(got)) out.push('外への fetch が connect-src で止まっていない');
+      if (!/script-src/.test(got)) out.push('外部スクリプトが script-src で止まっていない');
+      // 締めすぎていないか。自前のものは通らなければならない
+      try { await import('/assets/js/tone.js'); } catch (e) { out.push('自前の JS が止められた: ' + e.message); }
+      return out;
+    })()`);
+    for (const f of teeth || []) ng('CSP', f);
 
     console.log('描画の検査を実行');
   } catch (e) {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,18 @@
+// Cloudflare Workers（静的アセット）の設定。
+//
+// Pages ではなく Workers を使う。Cloudflare が「新規プロジェクトは Workers で
+// 始めるべき。Pages は引き続きサポートするが、今後の投資と機能開発は Workers に
+// 専念する」と言っているため。
+//
+// main は書かない。振る舞いを足すつもりが無いので、アセットを配るだけでよい。
+// Worker のコードが無いぶん、動く部分が減る。
+//
+// directory を "." にしているのは、index.html が置いてあるのがリポジトリの根で、
+// _headers もそこに要るから。配りたくないものは .assetsignore で外す。
+{
+  "name": "typing-engineer",
+  "compatibility_date": "2026-08-12",
+  "assets": {
+    "directory": "."
+  }
+}


### PR DESCRIPTION
Cloudflare Pages への移行にあわせて、README が長いあいだ宣言していたことを
機械が強制する形にする。あわせて、検査の空振りを二つ直した。

## なぜ Cloudflare か

帯域幅ではない。264 KB のサイトで 100 GB/月 には届かない。
**ヘッダーを置けること**が理由。GitHub Pages では一切指定できない。

README にはこう書いてきた。

> フォントも CDN もアイコン配信も使っていません。ネットワークへ出ていく通信はゼロです。

これが宣言のままだった。`connect-src 'none'` を置くと、うっかり CDN の URL を
書いた時点でブラウザが止める。

並走させるので、`_headers` は GitHub Pages 側では無視されるだけ。困らない。

## コミット

| | |
| --- | --- |
| `d33751d` | README と実装のズレを検査で落とす |
| `2a2c9af` | 落ちた理由を読めるようにする（`Page.enable` が無かった） |
| `bf57807` | CSP を置いて、外に出ないことを宣言から不変条件に変える |

三つとも単体で `npm run check` が通る。壊れた中間状態は無い。

## 見つけた既存のバグ

検査が `Page.enable` を呼んでいなかった。そのため
`addScriptToEvaluateOnNewDocument` が効かず、`window.__err` はずっと
`undefined` だった。読み込みで落ちたときの理由が、常にこう出ていた。

```
描画: 一覧に札が一枚も出ていない。読み込みで落ちている疑い: (見当たらない)
```

いまは出る。

```
描画: 一覧に札が一枚も出ていない。読み込みで落ちている疑い:
      Uncaught SyntaxError: Identifier 'LESSONS' has already been declared
```

**仕込みが空振りしても検査は緑になる。** そこが厄介なので、違反を拾う仕込みが
入っていなければ落とすようにした。

## unsafe-inline は外せない

打った字を `srcdoc` に流して走らせるのが主題で、中身は一打ごとに変わるので
ハッシュも nonce も置けない。`srcdoc` は親の CSP を継ぐ。

**守れるのは「インラインを止めること」ではなく「外に出る通信をゼロに保つこと」。**
`connect-src` が本体で、あとは付随。README にもそう書いた。

## 検査

二方向から見る。片方だけでは足りない。

- **壊していないか** — 五つの lang の完成形を描いて違反ゼロ。JS の課題は
  canvas に色が乗ったかまで見て、インラインスクリプトが本当に走ったことを確かめる
- **効いているか** — 外へ `fetch` と `script` を出し、CSP が止めたことを
  violation の発火で確かめる

二つめで `fetch` の失敗だけを見てはいけない。CORS でも、ネットワークが
繋がっていないときでも同じように失敗するので、**CSP を丸ごと消してもその検査は
通ってしまう。** 止めた主体が CSP だと言えるのは violation だけ。

README のズレも、書いてあるとおりに手を動かすと壊れる種類だけを見張る。
分類を id に改めたとき「題材を足す」の例が `'王道パターン'` のまま残っていて、
あれを写すと `GROUPS` に無い分類になる状態を取り逃したので足した。

## 確かめたこと

わざと壊して落ちることを確認した。

- CSP 七通り — `connect-src` を消す / 外に開く / CSP を丸ごと消す /
  サーバーが送らない / `script-src` を締めすぎる / `style-src` を締めすぎる /
  仕込みが空振りする
- README 七通り — 数のずれ三種 / 構成の欠けと実在しないファイル /
  例の分類と項目の抜け

手元では 5 言語すべての完成形が CSP 下で描画され、違反ゼロ。JS 課題の canvas は
`5,7,15,255`（`#05070f` 不透明）で、インラインスクリプトが走っている。

## Cloudflare 側の設定（この PR には含まれない）

| 項目 | 値 |
| --- | --- |
| Framework preset | None |
| Build command | **空欄** |
| Build output directory | `/` |
| 環境変数 | なし |

Build command に `npx wrangler deploy` は書かない。`wrangler deploy` は
Workers 用（Pages は `wrangler pages deploy`）、`wrangler.toml` を要求されるが
無い、そして Git 連携では wrangler 自体が要らない。

空にすれば `npx` の取得も走らないので、配信の経路にも依存パッケージがゼロになる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)